### PR TITLE
Removes API key as a requirement, add a basic readme

### DIFF
--- a/OTRRouting/OTRRoutingController.h
+++ b/OTRRouting/OTRRoutingController.h
@@ -16,15 +16,11 @@
 /** URL for routing server. Defaults to URL for Mapzen Turn-by-Turn production server. */
 @property (nonatomic, strong, nonnull) NSString *baseUrl;
 
-/** Mapzen Turn-by-Turn api key. */
-@property (nonatomic, strong, nonnull) NSString *apiKey;
+//** URL Query components that get added to the URL Request. If you're connecting to Mapzen's hosted service, you'll want to add your API key here. */
+@property (nonatomic, strong, nonnull) NSMutableArray<NSURLQueryItem*> *urlQueryComponents;
 
-/**
- Create a new routing controller configured to connect to the Mapzen Turn-by-Turn production server.
- 
- @param apiKey API to be used for routing requests.
- */
-- (instancetype _Nonnull)initWithApiKey:(NSString * _Nonnull)apiKey;
+/** Create a new routing controller configured to connect to the Mapzen Turn-by-Turn production server. */
+- (instancetype _Nonnull)init;
 
 /**
  Request a route.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+On The Road for iOS
+==========
+
+This is the official client for the Valhalla project (https://github.com/valhalla). It currently provides a basic implementation for pulling a route between multiple points, and is based on the work done by the good folks from TrailBehind for their GaiaGPS product (https://www.gaiagps.com/).
+
+We're currently actively developing it for integration into our official iOS SDK (https://github.com/mapzen/ios). Keep an eye on that space along with this project for more information!


### PR DESCRIPTION
Since we support changing the base URL, we also need to remove API key as a
requirement as that's purely Mapzen TBT related.

Fixes #3, #5
