### PR TITLE
Remove CoreLocation as a requirement

### DIFF
--- a/OTRRouting/OTRRoutingPoint.h
+++ b/OTRRouting/OTRRoutingPoint.h
@@ -12,7 +12,7 @@
 @interface OTRRoutingPoint : NSObject
 
 /** Coordinate of the point */
-@property (nonatomic, assign) CLLocationCoordinate2D coordinate;
+@property (nonatomic, assign) OTRGeoPoint coordinate;
 
 /** Type of location, either break or through. A break is a stop, so the first and last locations must be of type break. A through location is one that the route path travels through, and is useful to force a route to go through location. The path is not allowed to reverse direction at the through locations. If no type is provided, the type is assumed to be a break. */
 @property (nonatomic, assign) OTRRoutingPointType type;
@@ -22,7 +22,7 @@
 
 /** Create a new point.
  */
-+ (instancetype _Nonnull)pointWithCoordinate:(CLLocationCoordinate2D)coordinate type:(OTRRoutingPointType)type;
++ (instancetype _Nonnull)pointWithCoordinate:(OTRGeoPoint)coordinate type:(OTRRoutingPointType)type;
 
 /** Get the dictionary representation of the point, used for creating server query. */
 - (NSDictionary * _Nonnull)asDictionary;

--- a/OTRRouting/OTRRoutingPoint.m
+++ b/OTRRouting/OTRRoutingPoint.m
@@ -6,13 +6,12 @@
 //
 //
 
-#import <CoreLocation/CoreLocation.h>
 #import "OTRRoutingPoint.h"
 #import "OTRRoutingTypes.h"
 
 @implementation OTRRoutingPoint
 
-+ (instancetype _Nonnull)pointWithCoordinate:(CLLocationCoordinate2D)coordinate type:(OTRRoutingPointType)type {
++ (instancetype _Nonnull)pointWithCoordinate:(OTRGeoPoint)coordinate type:(OTRRoutingPointType)type {
   OTRRoutingPoint *point = [[OTRRoutingPoint alloc] init];
   point.coordinate = coordinate;
   point.type = type;

--- a/OTRRouting/OTRRoutingResultLeg.h
+++ b/OTRRouting/OTRRoutingResultLeg.h
@@ -8,8 +8,8 @@
 
 #import <Foundation/Foundation.h>
 #import <CoreGraphics/CoreGraphics.h>
-#import <CoreLocation/CoreLocation.h>
 #import "OTRRoutingResultManeuver.h"
+#import "OTRRoutingTypes.h"
 
 @interface OTRRoutingResultLeg : NSObject
 
@@ -29,7 +29,7 @@
  
  This array is owned by the leg, and will be free()'ed when the the leg is dealloc'ed. If you need to keep this array around past the life of this object, copy it to a new array owned by another object.
  */
-@property (nonatomic, readonly, nullable) CLLocationCoordinate2D *coordinates;
+@property (nonatomic, readonly, nullable) OTRGeoPoint *coordinates;
 
 /** Create a leg object by parsing an element of the leg array of the server json response. */
 + (instancetype _Nullable)legFromDictionary:(NSDictionary * _Nonnull)response;

--- a/OTRRouting/OTRRoutingResultLeg.m
+++ b/OTRRouting/OTRRoutingResultLeg.m
@@ -12,7 +12,7 @@
 
 @property (nonatomic, strong, nonnull) NSArray <OTRRoutingResultManeuver*>* maneuvers;
 @property (nonatomic, assign) NSUInteger coordinateCount;
-@property (nonatomic, assign, nullable) CLLocationCoordinate2D *coordinates;
+@property (nonatomic, assign, nullable) OTRGeoPoint *coordinates;
 
 @end
 
@@ -49,12 +49,12 @@
 }
 
 
-+ (CLLocationCoordinate2D*)decodePolyline:(NSString*)polyline length:(NSUInteger*)outputLength {
++ (OTRGeoPoint*)decodePolyline:(NSString*)polyline length:(NSUInteger*)outputLength {
   const char *bytes = [polyline UTF8String];
   NSUInteger length = [polyline lengthOfBytesUsingEncoding:NSUTF8StringEncoding];
   
   NSUInteger allocCount = length/4;
-  CLLocationCoordinate2D *coords = calloc(allocCount, sizeof(CLLocationCoordinate2D));
+  OTRGeoPoint *coords = calloc(allocCount, sizeof(OTRGeoPoint));
   
   NSUInteger idx = 0;
   NSUInteger coordIdx = 0;
@@ -87,11 +87,11 @@
     float deltaLon = ((res & 1) ? ~(res >> 1) : (res >> 1));
     longitude += deltaLon;
     
-    coords[coordIdx++] = CLLocationCoordinate2DMake(latitude * 1E-6, longitude * 1E-6);
+    coords[coordIdx++] = OTRGeoPointMake(latitude * 1E-6, longitude * 1E-6);
     
     if (coordIdx == allocCount) {
       allocCount += 10;
-      coords = realloc(coords, allocCount * sizeof(CLLocationCoordinate2D));
+      coords = realloc(coords, allocCount * sizeof(OTRGeoPoint));
     }
   }
   

--- a/OTRRouting/OTRRoutingTypes.h
+++ b/OTRRouting/OTRRoutingTypes.h
@@ -22,6 +22,14 @@ typedef NS_ENUM(NSUInteger, OTRRoutingCostingModel) {
   OTRRoutingCostingModelPedestrian
 };
 
+struct OTRGeoPoint {
+  double latitude;
+  double longitude;
+};
+typedef struct OTRGeoPoint OTRGeoPoint;
+
+OTRGeoPoint OTRGeoPointMake(double latitude, double longitude);
+
 @interface OTRRoutingTypes : NSObject
 
 + (NSString * _Nonnull)stringFromCostingModel:(OTRRoutingCostingModel)costing;

--- a/OTRRouting/OTRRoutingTypes.m
+++ b/OTRRouting/OTRRoutingTypes.m
@@ -8,6 +8,13 @@
 
 #import "OTRRoutingTypes.h"
 
+OTRGeoPoint OTRGeoPointMake(double latitude, double longitude){
+  struct OTRGeoPoint point;
+  point.latitude = latitude;
+  point.longitude = longitude;
+  return point;
+}
+
 @implementation OTRRoutingTypes
 
 + (NSString* _Nonnull)stringFromCostingModel:(OTRRoutingCostingModel)costing {

--- a/TBMapzenRouting.xcodeproj/project.pbxproj
+++ b/TBMapzenRouting.xcodeproj/project.pbxproj
@@ -9,7 +9,6 @@
 /* Begin PBXBuildFile section */
 		884C2B711D411E6A003E29FA /* OTRRoutingController.m in Sources */ = {isa = PBXBuildFile; fileRef = 884C2B661D411E6A003E29FA /* OTRRoutingController.m */; };
 		884C2B721D411E6B003E29FA /* OTRRoutingPoint.m in Sources */ = {isa = PBXBuildFile; fileRef = 884C2B681D411E6A003E29FA /* OTRRoutingPoint.m */; };
-		884C2B781D411EFA003E29FA /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 884C2B771D411EFA003E29FA /* CoreLocation.framework */; };
 		DB0EA1D21D673DB3005BB5C2 /* OTRRoutingResult.m in Sources */ = {isa = PBXBuildFile; fileRef = DB0EA1D11D673DB3005BB5C2 /* OTRRoutingResult.m */; };
 		DBBCD17F1D67401100458560 /* OTRRoutingResultLeg.m in Sources */ = {isa = PBXBuildFile; fileRef = DBBCD17E1D67401100458560 /* OTRRoutingResultLeg.m */; };
 		DBBCD1821D67419000458560 /* OTRRoutingResultManeuver.m in Sources */ = {isa = PBXBuildFile; fileRef = DBBCD1811D67419000458560 /* OTRRoutingResultManeuver.m */; };
@@ -35,7 +34,6 @@
 		884C2B661D411E6A003E29FA /* OTRRoutingController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OTRRoutingController.m; sourceTree = "<group>"; };
 		884C2B671D411E6A003E29FA /* OTRRoutingPoint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OTRRoutingPoint.h; sourceTree = "<group>"; };
 		884C2B681D411E6A003E29FA /* OTRRoutingPoint.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OTRRoutingPoint.m; sourceTree = "<group>"; };
-		884C2B771D411EFA003E29FA /* CoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
 		DB0EA1D01D673DB3005BB5C2 /* OTRRoutingResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OTRRoutingResult.h; sourceTree = "<group>"; };
 		DB0EA1D11D673DB3005BB5C2 /* OTRRoutingResult.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OTRRoutingResult.m; sourceTree = "<group>"; };
 		DBBCD17D1D67401100458560 /* OTRRoutingResultLeg.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OTRRoutingResultLeg.h; sourceTree = "<group>"; };
@@ -51,7 +49,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				884C2B781D411EFA003E29FA /* CoreLocation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -61,7 +58,6 @@
 		884C2B4F1D411E48003E29FA = {
 			isa = PBXGroup;
 			children = (
-				884C2B771D411EFA003E29FA /* CoreLocation.framework */,
 				884C2B5A1D411E48003E29FA /* OTRRouting */,
 				884C2B591D411E48003E29FA /* Products */,
 			);
@@ -129,7 +125,7 @@
 					};
 				};
 			};
-			buildConfigurationList = 884C2B531D411E48003E29FA /* Build configuration list for PBXProject "OTRRouting" */;
+			buildConfigurationList = 884C2B531D411E48003E29FA /* Build configuration list for PBXProject "TBMapzenRouting" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
@@ -266,7 +262,7 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		884C2B531D411E48003E29FA /* Build configuration list for PBXProject "OTRRouting" */ = {
+		884C2B531D411E48003E29FA /* Build configuration list for PBXProject "TBMapzenRouting" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				884C2B5F1D411E48003E29FA /* Debug */,


### PR DESCRIPTION
Replaces CLLocationCoordinate2D with OTRGeoPoint, thus removing the need for CoreLocation.

Fixes #6 
