### PR TITLE
Adds unit testing and ability to build dynamic framework version

### DIFF
--- a/TBMapzenRouting.xcodeproj/project.pbxproj
+++ b/TBMapzenRouting.xcodeproj/project.pbxproj
@@ -29,6 +29,12 @@
 		DBDE07121D774DED00EF020F /* OTRRoutingResultLeg.h in Headers */ = {isa = PBXBuildFile; fileRef = DBBCD17D1D67401100458560 /* OTRRoutingResultLeg.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DBDE07131D774DF400EF020F /* OTRRoutingResultManeuver.h in Headers */ = {isa = PBXBuildFile; fileRef = DBBCD1801D67419000458560 /* OTRRoutingResultManeuver.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DBDE07141D774DF700EF020F /* OTRRoutingTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = DBBCD1831D67432100458560 /* OTRRoutingTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DBDE07171D79E02E00EF020F /* OTRRoutingController.m in Sources */ = {isa = PBXBuildFile; fileRef = 884C2B661D411E6A003E29FA /* OTRRoutingController.m */; };
+		DBDE07181D79E03300EF020F /* OTRRoutingPoint.m in Sources */ = {isa = PBXBuildFile; fileRef = 884C2B681D411E6A003E29FA /* OTRRoutingPoint.m */; };
+		DBDE07191D79E03700EF020F /* OTRRoutingResult.m in Sources */ = {isa = PBXBuildFile; fileRef = DB0EA1D11D673DB3005BB5C2 /* OTRRoutingResult.m */; };
+		DBDE071A1D79E03B00EF020F /* OTRRoutingResultLeg.m in Sources */ = {isa = PBXBuildFile; fileRef = DBBCD17E1D67401100458560 /* OTRRoutingResultLeg.m */; };
+		DBDE071B1D79E03E00EF020F /* OTRRoutingResultManeuver.m in Sources */ = {isa = PBXBuildFile; fileRef = DBBCD1811D67419000458560 /* OTRRoutingResultManeuver.m */; };
+		DBDE071C1D79E04100EF020F /* OTRRoutingTypes.m in Sources */ = {isa = PBXBuildFile; fileRef = DBBCD1841D67432100458560 /* OTRRoutingTypes.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -323,6 +329,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DBDE071B1D79E03E00EF020F /* OTRRoutingResultManeuver.m in Sources */,
+				DBDE07181D79E03300EF020F /* OTRRoutingPoint.m in Sources */,
+				DBDE071C1D79E04100EF020F /* OTRRoutingTypes.m in Sources */,
+				DBDE071A1D79E03B00EF020F /* OTRRoutingResultLeg.m in Sources */,
+				DBDE07191D79E03700EF020F /* OTRRoutingResult.m in Sources */,
+				DBDE07171D79E02E00EF020F /* OTRRoutingController.m in Sources */,
 				DBDE06CF1D77452400EF020F /* on_the_roadTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/TBMapzenRouting.xcodeproj/project.pbxproj
+++ b/TBMapzenRouting.xcodeproj/project.pbxproj
@@ -13,7 +13,33 @@
 		DBBCD17F1D67401100458560 /* OTRRoutingResultLeg.m in Sources */ = {isa = PBXBuildFile; fileRef = DBBCD17E1D67401100458560 /* OTRRoutingResultLeg.m */; };
 		DBBCD1821D67419000458560 /* OTRRoutingResultManeuver.m in Sources */ = {isa = PBXBuildFile; fileRef = DBBCD1811D67419000458560 /* OTRRoutingResultManeuver.m */; };
 		DBBCD1851D67432100458560 /* OTRRoutingTypes.m in Sources */ = {isa = PBXBuildFile; fileRef = DBBCD1841D67432100458560 /* OTRRoutingTypes.m */; };
+		DBDE06CA1D77452400EF020F /* on_the_road.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DBDE06C11D77452400EF020F /* on_the_road.framework */; };
+		DBDE06CF1D77452400EF020F /* on_the_roadTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DBDE06CE1D77452400EF020F /* on_the_roadTests.m */; };
+		DBDE06D11D77452400EF020F /* on_the_road.h in Headers */ = {isa = PBXBuildFile; fileRef = DBDE06C31D77452400EF020F /* on_the_road.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DBDE06D81D77456100EF020F /* OTRRoutingController.m in Sources */ = {isa = PBXBuildFile; fileRef = 884C2B661D411E6A003E29FA /* OTRRoutingController.m */; };
+		DBDE06D91D77456100EF020F /* OTRRoutingPoint.m in Sources */ = {isa = PBXBuildFile; fileRef = 884C2B681D411E6A003E29FA /* OTRRoutingPoint.m */; };
+		DBDE06DA1D77456100EF020F /* OTRRoutingResult.m in Sources */ = {isa = PBXBuildFile; fileRef = DB0EA1D11D673DB3005BB5C2 /* OTRRoutingResult.m */; };
+		DBDE06DB1D77456100EF020F /* OTRRoutingResultLeg.m in Sources */ = {isa = PBXBuildFile; fileRef = DBBCD17E1D67401100458560 /* OTRRoutingResultLeg.m */; };
+		DBDE06DC1D77456100EF020F /* OTRRoutingResultManeuver.m in Sources */ = {isa = PBXBuildFile; fileRef = DBBCD1811D67419000458560 /* OTRRoutingResultManeuver.m */; };
+		DBDE06DD1D77456100EF020F /* OTRRoutingTypes.m in Sources */ = {isa = PBXBuildFile; fileRef = DBBCD1841D67432100458560 /* OTRRoutingTypes.m */; };
+		DBDE070C1D774D8100EF020F /* OTRRouting.h in Headers */ = {isa = PBXBuildFile; fileRef = 884C2B641D411E6A003E29FA /* OTRRouting.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DBDE070F1D774DE100EF020F /* OTRRoutingController.h in Headers */ = {isa = PBXBuildFile; fileRef = 884C2B651D411E6A003E29FA /* OTRRoutingController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DBDE07101D774DE500EF020F /* OTRRoutingPoint.h in Headers */ = {isa = PBXBuildFile; fileRef = 884C2B671D411E6A003E29FA /* OTRRoutingPoint.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DBDE07111D774DE900EF020F /* OTRRoutingResult.h in Headers */ = {isa = PBXBuildFile; fileRef = DB0EA1D01D673DB3005BB5C2 /* OTRRoutingResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DBDE07121D774DED00EF020F /* OTRRoutingResultLeg.h in Headers */ = {isa = PBXBuildFile; fileRef = DBBCD17D1D67401100458560 /* OTRRoutingResultLeg.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DBDE07131D774DF400EF020F /* OTRRoutingResultManeuver.h in Headers */ = {isa = PBXBuildFile; fileRef = DBBCD1801D67419000458560 /* OTRRoutingResultManeuver.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DBDE07141D774DF700EF020F /* OTRRoutingTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = DBBCD1831D67432100458560 /* OTRRoutingTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		DBDE06CB1D77452400EF020F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 884C2B501D411E48003E29FA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DBDE06C01D77452400EF020F;
+			remoteInfo = on_the_road;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
 		884C2B561D411E48003E29FA /* CopyFiles */ = {
@@ -42,6 +68,12 @@
 		DBBCD1811D67419000458560 /* OTRRoutingResultManeuver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OTRRoutingResultManeuver.m; sourceTree = "<group>"; };
 		DBBCD1831D67432100458560 /* OTRRoutingTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OTRRoutingTypes.h; sourceTree = "<group>"; };
 		DBBCD1841D67432100458560 /* OTRRoutingTypes.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OTRRoutingTypes.m; sourceTree = "<group>"; };
+		DBDE06C11D77452400EF020F /* on_the_road.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = on_the_road.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DBDE06C31D77452400EF020F /* on_the_road.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = on_the_road.h; sourceTree = "<group>"; };
+		DBDE06C41D77452400EF020F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		DBDE06C91D77452400EF020F /* on_the_roadTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = on_the_roadTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		DBDE06CE1D77452400EF020F /* on_the_roadTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = on_the_roadTests.m; sourceTree = "<group>"; };
+		DBDE06D01D77452400EF020F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -52,6 +84,21 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		DBDE06BD1D77452400EF020F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DBDE06C61D77452400EF020F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DBDE06CA1D77452400EF020F /* on_the_road.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -59,6 +106,8 @@
 			isa = PBXGroup;
 			children = (
 				884C2B5A1D411E48003E29FA /* OTRRouting */,
+				DBDE06C21D77452400EF020F /* on_the_road */,
+				DBDE06CD1D77452400EF020F /* on_the_roadTests */,
 				884C2B591D411E48003E29FA /* Products */,
 			);
 			sourceTree = "<group>";
@@ -67,6 +116,8 @@
 			isa = PBXGroup;
 			children = (
 				884C2B581D411E48003E29FA /* libOTRRouting.a */,
+				DBDE06C11D77452400EF020F /* on_the_road.framework */,
+				DBDE06C91D77452400EF020F /* on_the_roadTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -91,7 +142,43 @@
 			path = OTRRouting;
 			sourceTree = "<group>";
 		};
+		DBDE06C21D77452400EF020F /* on_the_road */ = {
+			isa = PBXGroup;
+			children = (
+				DBDE06C31D77452400EF020F /* on_the_road.h */,
+				DBDE06C41D77452400EF020F /* Info.plist */,
+			);
+			path = on_the_road;
+			sourceTree = "<group>";
+		};
+		DBDE06CD1D77452400EF020F /* on_the_roadTests */ = {
+			isa = PBXGroup;
+			children = (
+				DBDE06CE1D77452400EF020F /* on_the_roadTests.m */,
+				DBDE06D01D77452400EF020F /* Info.plist */,
+			);
+			path = on_the_roadTests;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		DBDE06BE1D77452400EF020F /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DBDE06D11D77452400EF020F /* on_the_road.h in Headers */,
+				DBDE070C1D774D8100EF020F /* OTRRouting.h in Headers */,
+				DBDE070F1D774DE100EF020F /* OTRRoutingController.h in Headers */,
+				DBDE07101D774DE500EF020F /* OTRRoutingPoint.h in Headers */,
+				DBDE07111D774DE900EF020F /* OTRRoutingResult.h in Headers */,
+				DBDE07121D774DED00EF020F /* OTRRoutingResultLeg.h in Headers */,
+				DBDE07131D774DF400EF020F /* OTRRoutingResultManeuver.h in Headers */,
+				DBDE07141D774DF700EF020F /* OTRRoutingTypes.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
 		884C2B571D411E48003E29FA /* OTRRouting */ = {
@@ -111,6 +198,42 @@
 			productReference = 884C2B581D411E48003E29FA /* libOTRRouting.a */;
 			productType = "com.apple.product-type.library.static";
 		};
+		DBDE06C01D77452400EF020F /* on_the_road */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DBDE06D61D77452400EF020F /* Build configuration list for PBXNativeTarget "on_the_road" */;
+			buildPhases = (
+				DBDE06BC1D77452400EF020F /* Sources */,
+				DBDE06BD1D77452400EF020F /* Frameworks */,
+				DBDE06BE1D77452400EF020F /* Headers */,
+				DBDE06BF1D77452400EF020F /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = on_the_road;
+			productName = on_the_road;
+			productReference = DBDE06C11D77452400EF020F /* on_the_road.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		DBDE06C81D77452400EF020F /* on_the_roadTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DBDE06D71D77452400EF020F /* Build configuration list for PBXNativeTarget "on_the_roadTests" */;
+			buildPhases = (
+				DBDE06C51D77452400EF020F /* Sources */,
+				DBDE06C61D77452400EF020F /* Frameworks */,
+				DBDE06C71D77452400EF020F /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				DBDE06CC1D77452400EF020F /* PBXTargetDependency */,
+			);
+			name = on_the_roadTests;
+			productName = on_the_roadTests;
+			productReference = DBDE06C91D77452400EF020F /* on_the_roadTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -122,6 +245,14 @@
 				TargetAttributes = {
 					884C2B571D411E48003E29FA = {
 						CreatedOnToolsVersion = 7.3.1;
+					};
+					DBDE06C01D77452400EF020F = {
+						CreatedOnToolsVersion = 8.0;
+						ProvisioningStyle = Automatic;
+					};
+					DBDE06C81D77452400EF020F = {
+						CreatedOnToolsVersion = 8.0;
+						ProvisioningStyle = Automatic;
 					};
 				};
 			};
@@ -138,9 +269,28 @@
 			projectRoot = "";
 			targets = (
 				884C2B571D411E48003E29FA /* OTRRouting */,
+				DBDE06C01D77452400EF020F /* on_the_road */,
+				DBDE06C81D77452400EF020F /* on_the_roadTests */,
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		DBDE06BF1D77452400EF020F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DBDE06C71D77452400EF020F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		884C2B541D411E48003E29FA /* Sources */ = {
@@ -156,7 +306,36 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		DBDE06BC1D77452400EF020F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DBDE06D81D77456100EF020F /* OTRRoutingController.m in Sources */,
+				DBDE06D91D77456100EF020F /* OTRRoutingPoint.m in Sources */,
+				DBDE06DA1D77456100EF020F /* OTRRoutingResult.m in Sources */,
+				DBDE06DB1D77456100EF020F /* OTRRoutingResultLeg.m in Sources */,
+				DBDE06DC1D77456100EF020F /* OTRRoutingResultManeuver.m in Sources */,
+				DBDE06DD1D77456100EF020F /* OTRRoutingTypes.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DBDE06C51D77452400EF020F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DBDE06CF1D77452400EF020F /* on_the_roadTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		DBDE06CC1D77452400EF020F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DBDE06C01D77452400EF020F /* on_the_road */;
+			targetProxy = DBDE06CB1D77452400EF020F /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		884C2B5F1D411E48003E29FA /* Debug */ = {
@@ -259,6 +438,84 @@
 			};
 			name = Release;
 		};
+		DBDE06D21D77452400EF020F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = on_the_road/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mapzen.on-the-road";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		DBDE06D31D77452400EF020F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = on_the_road/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mapzen.on-the-road";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		DBDE06D41D77452400EF020F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				INFOPLIST_FILE = on_the_roadTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mapzen.on-the-roadTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		DBDE06D51D77452400EF020F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				INFOPLIST_FILE = on_the_roadTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mapzen.on-the-roadTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -279,6 +536,22 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		DBDE06D61D77452400EF020F /* Build configuration list for PBXNativeTarget "on_the_road" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DBDE06D21D77452400EF020F /* Debug */,
+				DBDE06D31D77452400EF020F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		DBDE06D71D77452400EF020F /* Build configuration list for PBXNativeTarget "on_the_roadTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DBDE06D41D77452400EF020F /* Debug */,
+				DBDE06D51D77452400EF020F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 /* End XCConfigurationList section */
 	};

--- a/on_the_road/Info.plist
+++ b/on_the_road/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/on_the_road/on_the_road.h
+++ b/on_the_road/on_the_road.h
@@ -1,0 +1,20 @@
+//
+//  on_the_road.h
+//  on_the_road
+//
+//  Created by Matt Smollinger on 8/31/16.
+//  Copyright © 2016 Trailbehind inc. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for on_the_road.
+FOUNDATION_EXPORT double on_the_roadVersionNumber;
+
+//! Project version string for on_the_road.
+FOUNDATION_EXPORT const unsigned char on_the_roadVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <on_the_road/PublicHeader.h>
+
+
+#import "OTRRouting.h"

--- a/on_the_roadTests/Info.plist
+++ b/on_the_roadTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/on_the_roadTests/on_the_roadTests.m
+++ b/on_the_roadTests/on_the_roadTests.m
@@ -1,0 +1,39 @@
+//
+//  on_the_roadTests.m
+//  on_the_roadTests
+//
+//  Created by Matt Smollinger on 8/31/16.
+//  Copyright © 2016 Trailbehind inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+@interface on_the_roadTests : XCTestCase
+
+@end
+
+@implementation on_the_roadTests
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)testExample {
+    // This is an example of a functional test case.
+    // Use XCTAssert and related functions to verify your tests produce the correct results.
+}
+
+- (void)testPerformanceExample {
+    // This is an example of a performance test case.
+    [self measureBlock:^{
+        // Put the code you want to measure the time of here.
+    }];
+}
+
+@end

--- a/on_the_roadTests/on_the_roadTests.m
+++ b/on_the_roadTests/on_the_roadTests.m
@@ -7,6 +7,7 @@
 //
 
 #import <XCTest/XCTest.h>
+#import "OTRRouting.h"
 
 @interface on_the_roadTests : XCTestCase
 
@@ -24,16 +25,8 @@
     [super tearDown];
 }
 
-- (void)testExample {
-    // This is an example of a functional test case.
-    // Use XCTAssert and related functions to verify your tests produce the correct results.
+- (void)testRoutingControllerInstantiation {
+  OTRRoutingController *controller = [[OTRRoutingController alloc] init];
+  XCTAssertNotNil(controller, "Controller is nil");
 }
-
-- (void)testPerformanceExample {
-    // This is an example of a performance test case.
-    [self measureBlock:^{
-        // Put the code you want to measure the time of here.
-    }];
-}
-
 @end


### PR DESCRIPTION
Fixes #9 - instead of replacing a static library we can build both a static library and a dynamic framework target. This seems like the best of both worlds scenario as it maintains compatibility with existing use cases while enabling seamless integration with newer projects in both obj-c and swift without having to require cocoapods.

Begins work on #12 by adding unit test capabilities to the project's dynamic framework target. We don't currently have any unit test coverage - that will come in a future push.
