### PR TITLE
Send current locale language by default

### DIFF
--- a/OTRRouting/OTRRoutingController.h
+++ b/OTRRouting/OTRRoutingController.h
@@ -30,6 +30,12 @@
 /** Create a new routing controller configured to connect to the Mapzen Turn-by-Turn production server. */
 - (instancetype _Nonnull)init;
 
+/** Create a new routing controller configured to connect to the session. Useful for testing
+
+ @param session NSURLSession to route requests through
+ */
+- (instancetype _Nonnull)initWithSessionManager:(NSURLSession* _Nonnull)session;
+
 /**
  Request a route.
  

--- a/TBMapzenRouting.xcodeproj/project.pbxproj
+++ b/TBMapzenRouting.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		7DC7F09E1E73583B009E722B /* OTRRoutingControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7DC7F09D1E73583B009E722B /* OTRRoutingControllerTests.m */; };
 		884C2B711D411E6A003E29FA /* OTRRoutingController.m in Sources */ = {isa = PBXBuildFile; fileRef = 884C2B661D411E6A003E29FA /* OTRRoutingController.m */; };
 		884C2B721D411E6B003E29FA /* OTRRoutingPoint.m in Sources */ = {isa = PBXBuildFile; fileRef = 884C2B681D411E6A003E29FA /* OTRRoutingPoint.m */; };
 		DB0EA1D21D673DB3005BB5C2 /* OTRRoutingResult.m in Sources */ = {isa = PBXBuildFile; fileRef = DB0EA1D11D673DB3005BB5C2 /* OTRRoutingResult.m */; };
@@ -60,6 +61,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		7DC7F09D1E73583B009E722B /* OTRRoutingControllerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OTRRoutingControllerTests.m; sourceTree = "<group>"; };
 		884C2B581D411E48003E29FA /* libOTRRouting.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libOTRRouting.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		884C2B641D411E6A003E29FA /* OTRRouting.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OTRRouting.h; sourceTree = "<group>"; };
 		884C2B651D411E6A003E29FA /* OTRRoutingController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OTRRoutingController.h; sourceTree = "<group>"; };
@@ -162,6 +164,7 @@
 			children = (
 				DBDE06CE1D77452400EF020F /* on_the_roadTests.m */,
 				DBDE06D01D77452400EF020F /* Info.plist */,
+				7DC7F09D1E73583B009E722B /* OTRRoutingControllerTests.m */,
 			);
 			path = on_the_roadTests;
 			sourceTree = "<group>";
@@ -331,6 +334,7 @@
 			files = (
 				DBDE071B1D79E03E00EF020F /* OTRRoutingResultManeuver.m in Sources */,
 				DBDE07181D79E03300EF020F /* OTRRoutingPoint.m in Sources */,
+				7DC7F09E1E73583B009E722B /* OTRRoutingControllerTests.m in Sources */,
 				DBDE071C1D79E04100EF020F /* OTRRoutingTypes.m in Sources */,
 				DBDE071A1D79E03B00EF020F /* OTRRoutingResultLeg.m in Sources */,
 				DBDE07191D79E03700EF020F /* OTRRoutingResult.m in Sources */,

--- a/on_the_roadTests/OTRRoutingControllerTests.m
+++ b/on_the_roadTests/OTRRoutingControllerTests.m
@@ -1,0 +1,96 @@
+//
+//  OTRRoutingControllerTests.m
+//  TBMapzenRouting
+//
+//  Created by Sarah Lensing on 3/10/17.
+//  Copyright © 2017 Trailbehind inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+#import "OTRRoutingController.h"
+
+
+@interface TestSessionDataTask : NSURLSessionDataTask
+
+@end
+
+@implementation TestSessionDataTask
+
+- (void)resume {
+
+}
+
+@end
+
+
+@interface TestUrlSession : NSURLSession
+
+@property (nonatomic, strong) NSDictionary *queryParameters;
+
+@end
+
+@implementation TestUrlSession
+
+@synthesize queryParameters;
+
+- (NSURLSessionDataTask *)dataTaskWithURL:(NSURL *)url completionHandler:(void (^)(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error))completionHandler {
+  NSString *decoded = [[url.query stringByRemovingPercentEncoding] stringByReplacingOccurrencesOfString:@"json=" withString:@""];
+  NSData *data = [decoded dataUsingEncoding:NSUTF8StringEncoding];
+  NSError *error;
+  queryParameters = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingAllowFragments error:&error];
+  return [[TestSessionDataTask alloc] init];
+}
+
+@end
+
+@interface OTRRoutingControllerTests : XCTestCase {
+  OTRRoutingController *controller;
+  TestUrlSession *urlSessionManager;
+}
+
+@end
+
+
+@implementation OTRRoutingControllerTests
+
+- (void)setUp {
+  [super setUp];
+  urlSessionManager = [[TestUrlSession alloc] init];
+  controller = [[OTRRoutingController alloc] initWithSessionManager:urlSessionManager];
+}
+
+- (void)testCurrentLocaleLanguageSetByDefault {
+  OTRRoutingPoint *loc1 = [[OTRRoutingPoint alloc] init];
+  OTRRoutingPoint *loc2 = [[OTRRoutingPoint alloc] init];
+  NSArray<OTRRoutingPoint*> *locations = [NSArray arrayWithObjects:loc1, loc2, nil];
+  [controller requestRouteWithLocations:locations
+                            costingModel:OTRRoutingCostingModelAuto
+                           costingOption:nil
+                       directionsOptions:nil
+                                callback:^(OTRRoutingResult * _Nullable result, id  _Nullable invalidationToken, NSError * _Nullable error) {
+                                  //
+                                }];
+  NSDictionary *directionsOptions = [urlSessionManager.queryParameters objectForKey:@"directions_options"];
+  XCTAssertNotNil(directionsOptions);
+  XCTAssertEqualObjects([directionsOptions objectForKey:@"language"], [NSLocale currentLocale].languageCode);
+}
+
+- (void)testLanguageSetInDirectionsOptions {
+  OTRRoutingPoint *loc1 = [[OTRRoutingPoint alloc] init];
+  OTRRoutingPoint *loc2 = [[OTRRoutingPoint alloc] init];
+  NSArray<OTRRoutingPoint*> *locations = [NSArray arrayWithObjects:loc1, loc2, nil];
+  NSDictionary *options = [NSDictionary dictionaryWithObject:@"fr-FR" forKey:@"language"];
+  [controller requestRouteWithLocations:locations
+                           costingModel:OTRRoutingCostingModelAuto
+                          costingOption:nil
+                      directionsOptions:options
+                               callback:^(OTRRoutingResult * _Nullable result, id  _Nullable invalidationToken, NSError * _Nullable error) {
+                                 //
+                               }];
+  NSDictionary *directionsOptions = [urlSessionManager.queryParameters objectForKey:@"directions_options"];
+  XCTAssertNotNil(directionsOptions);
+  XCTAssertEqualObjects([directionsOptions objectForKey:@"language"], @"fr-FR");
+}
+
+@end


### PR DESCRIPTION
- Adds the current locale's current language into the requested directions options if not specified
- Adds `OTRRoutingController` constructor given a `NSURLSession` for testing
- Adds tests to ensure correct language code is sent

Closes #26 