### PR TITLE
Refactor OTRRoutingController constructor

### DIFF
--- a/OTRRouting/OTRRoutingController.h
+++ b/OTRRouting/OTRRoutingController.h
@@ -42,7 +42,7 @@
  @param locations Locations to route to/thru
  @param costing Costing mode
  @param costingOptions costing options
- @param directionsOptions options for directions output
+ @param directionsOptions options for directions output. Note that if you request a language that is not supported, the router will default to use english.
  @param callback Callback function. 
 
  @return an NSURLSessionDataTask object that can be used to cancel the routing request before it has completed.

--- a/OTRRouting/OTRRoutingController.m
+++ b/OTRRouting/OTRRoutingController.m
@@ -19,12 +19,7 @@
 @implementation OTRRoutingController
 
 - (instancetype _Nonnull)init {
-  self = [super init];
-  self.baseUrl = @"https://valhalla.mapzen.com/route?";
-  self.urlSessionManager = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
-  self.urlQueryComponents = [[NSMutableArray alloc] init];
-  self.locale = [NSLocale currentLocale];
-  return self;
+  return [self initWithSessionManager:[NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]]];
 }
 
 - (instancetype _Nonnull)initWithSessionManager:(NSURLSession*  _Nonnull)session {


### PR DESCRIPTION
- DRY'er constructor for `OTRRoutingController`
- Updated documentation about router language fallback behavior